### PR TITLE
chore: remove AlphaLend from Bluefin

### DIFF
--- a/defi/src/protocols/data4.ts
+++ b/defi/src/protocols/data4.ts
@@ -13544,30 +13544,6 @@ const data4: Protocol[] = [
     listedAt: 1746711348,
   },
   {
-    id: "6153",
-    name: "AlphaLend",
-    address: "sui:0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca",
-    symbol: "BLUE",
-    url: "https://trade.bluefin.io/lend",
-    description:
-      "AlphaLend is a decentralized, non-custodial lending and borrowing protocol built on the SUI blockchain. It allows users to earn interest on deposited assets and borrow against their deposited assets without intermediaries. The protocol is designed to be composable, efficient, and secure, enabling developers and users to access core DeFi primitives in a trustless manner.",
-    chain: "Sui",
-    logo: `${baseIconsUrl}/alphalend.png`,
-    audits: "0",
-    gecko_id: "bluefin",
-    cmcId: "12114",
-    category: "Lending",
-    chains: ["Sui"],
-    module: "bluefin-alphalend/index.js",
-    twitter: "bluefinapp",
-    oraclesBreakdown: [{ name: "Pyth", type: "Primary", proof: [] }],
-    parentProtocol: "parent#bluefin",
-    listedAt: 1746735537,
-    dimensions: {
-      fees: "bluefin-alphalend"
-    }
-  },
-  {
     id: "6154",
     name: "Arena DEX",
     address: "avax:0xb8d7710f7d8349a506b75dd184f05777c82dad0c",


### PR DESCRIPTION
## What

Removes AlphaLend from Bluefin on DefiLlama. The Bluefin–AlphaLend partnership has ended, so AlphaLend should no longer report TVL/fees/revenue under the Bluefin parent protocol.

## Change

Remove the AlphaLend protocol entry (id `6153`, `parentProtocol: parent#bluefin`) from `defi/src/protocols/data4.ts`.

## Notes

- Targets this fork's default branch for review; the upstream DefiLlama PR will be opened manually after merge.
- The `parent#bluefin` protocol itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
